### PR TITLE
fix: No longer need to manually calls session$ns() with shinychat (#1…

### DIFF
--- a/r-package/DESCRIPTION
+++ b/r-package/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     purrr,
     rlang,
     shiny,
-    shinychat,
+    shinychat (>= 0.2.0),
     whisker,
     xtable
 Encoding: UTF-8

--- a/r-package/R/querychat.R
+++ b/r-package/R/querychat.R
@@ -175,7 +175,7 @@ querychat_server <- function(id, querychat_config) {
     append_output <- function(...) {
       txt <- paste0(...)
       shinychat::chat_append_message(
-        session$ns("chat"),
+        "chat",
         list(role = "assistant", content = txt),
         chunk = TRUE,
         operation = "append",
@@ -259,11 +259,11 @@ querychat_server <- function(id, querychat_config) {
     # the chat model to see.
     if (!is.null(greeting)) {
       if (isTRUE(any(nzchar(greeting)))) {
-        shinychat::chat_append(session$ns("chat"), greeting)
+        shinychat::chat_append("chat", greeting)
       }
     } else {
       shinychat::chat_append(
-        session$ns("chat"),
+        "chat",
         chat$stream_async(
           "Please give me a friendly greeting. Include a few sample prompts in a two-level bulleted list."
         )
@@ -274,7 +274,7 @@ querychat_server <- function(id, querychat_config) {
     shiny::observeEvent(input$chat_user_input, {
       # Add user message to the chat history
       shinychat::chat_append(
-        session$ns("chat"),
+        "chat",
         chat$stream_async(input$chat_user_input)
       )
     })


### PR DESCRIPTION
…0 #27)

This is a re-submission of #10 because the R version is currently broken without it.